### PR TITLE
Support CORS requests

### DIFF
--- a/lib/kanoko/application/convert.rb
+++ b/lib/kanoko/application/convert.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra'
 require 'net/http'
 require 'tempfile'

--- a/test/test_application_convert.rb
+++ b/test/test_application_convert.rb
@@ -6,7 +6,7 @@ class TestKanokoApplicationConvert < Minitest::Test
   class TestApp < Kanoko::Application::Convert
     class ResponseMock < Struct.new(:body, :content_type)
     end
-    def http_get(uri)
+    def http_get(uri, headers)
       path = uri.to_s[7..-1] # 7 = 'http://'
       path.sub!(/\?.*/, '')
       ResponseMock.new(File.read("test/#{URI.decode_www_form_component(path)}"), "image/jpeg")


### PR DESCRIPTION
Currently, Request Headers will lost in this app.
In the case of CORS request, We will be inconvenienced.

We should delegate Request Headers from Client to Resource.